### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ keep the installation process as user friendly as possible.
 
      `mount -o remount,size=1G /run/archiso/cowspace`
 
-2. Clone this repository: `git clone git://github.com/jorgeluiscarrillo/arch-setup`
+2. Clone this repository: `git clone https://github.com/jorgeluiscarrillo/arch-setup`
 3. Run the script: `cd arch-setup/ && ./setup`
 
 ## Features


### PR DESCRIPTION
**https** instead of **git** because otherwise many users will probably get an error message like this:

`Cloning into 'arch-setup'...`
`fatal: unable to connect to github.com`
`github.com[0: 140.82.118.3]: errno=Connection refused`

